### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-SimpleFingerGestures-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/777)
 [![Release](https://jitpack.io/v/in.championswimmer/SimpleFingerGestures_Android_Library.svg)](https://jitpack.io/#in.championswimmer/SimpleFingerGestures_Android_Library)
 
-##Example
+## Example
 ![](./screens/1.gif) ![](./screens/2.gif)   
 ![](./screens/4.gif) ![](./screens/3.gif)  
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
